### PR TITLE
Upscale no flow boundary conditions

### DIFF
--- a/opm/verteq/verteq.hpp
+++ b/opm/verteq/verteq.hpp
@@ -134,6 +134,19 @@ public:
 	virtual const std::vector<double>& src () = 0;
 
 	/**
+	 * @brief Accessor method for the list of boundary conditions in
+	 *        the upscaled grid.
+	 *
+	 * @return A structure containing the boundary conditions on the
+	 *         upscaled grid.
+	 *
+	 * @note The lifetime of the returned object is no longer than that
+	 *       of the upscaling object. You do NOT own this object; do not
+	 *       dispose of the pointer.
+	 */
+	virtual const FlowBoundaryConditions* bcs () = 0;
+
+	/**
 	 * Create an upscaled view of the domain state.
 	 *
 	 * This must be done in a separate method since the state is not

--- a/opm/verteq/wrapper.cpp
+++ b/opm/verteq/wrapper.cpp
@@ -56,7 +56,7 @@ VertEqWrapper <Simulator>::VertEqWrapper (
 	                     rock_comp_props,
 	                     *wells_mgr,
 	                     ve->src (),
-	                     bcs,
+	                     ve->bcs (),
 	                     linsolver,
 	                     gravity);
 }


### PR DESCRIPTION
The conditions are not really upscaled, but a framework is put into place which allows other boundary conditions to be introduced later. The current code just checks if there is only no-flow conditions, and applies the same to the upscaled grid.
