### PR TITLE
Add exception handlers to all unit tests, tutorials and examples

### DIFF
--- a/examples/2d/src/co2_2d.cpp
+++ b/examples/2d/src/co2_2d.cpp
@@ -22,7 +22,7 @@ using namespace Opm;
 using namespace Opm::parameter;
 using namespace std;
 
-int main (int argc, char *argv[]) {
+int main (int argc, char *argv[]) try {
 	// read parameters from command-line
 	ParameterGroup param (argc, argv, false);
 
@@ -73,3 +73,8 @@ int main (int argc, char *argv[]) {
 	// done
 	return 0;
 }
+catch (const std::exception &e) {
+    std::cerr << "Program threw an exception: " << e.what() << "\n";
+    throw;
+}
+

--- a/examples/3d/src/co2_3d.cpp
+++ b/examples/3d/src/co2_3d.cpp
@@ -21,7 +21,7 @@ using namespace Opm;
 using namespace Opm::parameter;
 using namespace std;
 
-int main (int argc, char *argv[]) {
+int main (int argc, char *argv[]) try {
 	// read parameters from command-line
 	ParameterGroup param (argc, argv, false);
 
@@ -71,4 +71,8 @@ int main (int argc, char *argv[]) {
 
 	// done
 	return 0;
+}
+catch (const std::exception &e) {
+    std::cerr << "Program threw an exception: " << e.what() << "\n";
+    throw;
 }


### PR DESCRIPTION
make the exception handling code consistent with opm/opm-core#352
