### PR TITLE
Put gravity handling in the upscaling object

### DIFF
--- a/opm/verteq/verteq.cpp
+++ b/opm/verteq/verteq.cpp
@@ -38,7 +38,7 @@ struct VertEqImpl : public VertEq {
 	           const Wells* wells,
 	           const vector<double>& fullSrc,
 	           const FlowBoundaryConditions* fullBcs,
-	           const double* gravity);
+	           const double* fullGravity);
 	// public methods defined in the interface
 	virtual const UnstructuredGrid& grid();
 	virtual const Wells* wells();
@@ -65,6 +65,10 @@ struct VertEqImpl : public VertEq {
 	// boundary conditions
 	void assert_noflow (const FlowBoundaryConditions* bcs);
 	virtual const FlowBoundaryConditions* bcs ();
+
+	// gravity
+	const double* grav_vec;
+	virtual const double* gravity ();
 };
 
 VertEq*
@@ -75,14 +79,14 @@ VertEq::create (const string& title,
                 const Wells* wells,
                 const vector<double>& fullSrc,
                 const FlowBoundaryConditions* fullBcs,
-                const double* gravity) {
+                const double* fullGravity) {
 	// this is just to avoid warnings about unused variables
 	static_cast <void> (title);
 	static_cast <void> (args);
 
 	// we don't provide any parameters to do tuning yet
 	auto_ptr <VertEqImpl> impl (new VertEqImpl ());
-	impl->init (fullGrid, fullProps, wells, fullSrc, fullBcs, gravity);
+	impl->init (fullGrid, fullProps, wells, fullSrc, fullBcs, fullGravity);
 	return impl.release();
 }
 
@@ -92,10 +96,13 @@ VertEqImpl::init(const UnstructuredGrid& fullGrid,
                  const Wells* wells,
                  const vector<double>& fullSrc,
                  const FlowBoundaryConditions* fullBcs,
-                 const double* gravity) {
+                 const double* fullGravity) {
+	// store a pointer to the original gravity vector passed to us
+	grav_vec = fullGravity;
+
 	// generate a two-dimensional upscaling as soon as we get the grid
 	ts = auto_ptr <TopSurf> (TopSurf::create (fullGrid));
-	pr = auto_ptr <VertEqProps> (VertEqProps::create (fullProps, *ts, gravity));
+	pr = auto_ptr <VertEqProps> (VertEqProps::create (fullProps, *ts, grav_vec));
 	// create a separate, but identical, list of wells we can work on
 	w = clone_wells(wells);
 	translate_wells ();
@@ -108,6 +115,13 @@ VertEqImpl::init(const UnstructuredGrid& fullGrid,
 	assert_noflow (fullBcs);
 	// rely on the fact that no boundary conditions means no-flow
 	bnd_cond = flow_conditions_construct (0);
+}
+
+const double*
+VertEqImpl::gravity () {
+	// simply return the original two first items; the underlaying simulator
+	// cannot "see" the last dimension, because it only know of two elements.
+	return grav_vec;
 }
 
 const FlowBoundaryConditions*

--- a/opm/verteq/verteq.hpp
+++ b/opm/verteq/verteq.hpp
@@ -82,7 +82,7 @@ public:
 	                       const Wells* fullWells,
 	                       const std::vector<double>& fullSrc,
 	                       const FlowBoundaryConditions* fullBcs,
-	                       const double* gravity);
+	                       const double* fullGravity);
 
 	// virtual destructor, actual functionality relayed to real impl.
 	virtual ~VertEq () {}
@@ -145,6 +145,19 @@ public:
 	 *       dispose of the pointer.
 	 */
 	virtual const FlowBoundaryConditions* bcs () = 0;
+
+	/**
+	 * @brief Gravity that should be used in the upscaled, two-
+	 *        dimensional model.
+	 *
+	 * @return Pointer to an array of two double, describing the
+	 *         gravity in x- and y- directions (z has been upscaled away).
+	 *
+	 * @note The lifetime of the returned array is no longer than that
+	 *       of the upscaling object. You do NOT own this pointer and
+	 *       should NOT dispose of it.
+	 */
+	virtual const double* gravity () = 0;
 
 	/**
 	 * Create an upscaled view of the domain state.

--- a/opm/verteq/wrapper.cpp
+++ b/opm/verteq/wrapper.cpp
@@ -64,7 +64,7 @@ VertEqWrapper <Simulator>::VertEqWrapper (
 	                     ve->src (),
 	                     ve->bcs (),
 	                     linsolver,
-	                     gravity);
+	                     ve->gravity ());
 }
 
 template <typename Simulator> Event&


### PR DESCRIPTION
Now it is the upscaling that returns the gravity vector to use and not the wrapper itself, even though it ends up with the same implementation.
