### PR TITLE
Commit bebcc093 breaks build on GCC 4.4

### DIFF
--- a/opm/verteq/topsurf.cpp
+++ b/opm/verteq/topsurf.cpp
@@ -13,6 +13,7 @@
 #include <iosfwd> // ostream
 #include <map>
 #include <memory> // auto_ptr
+#include <numeric> // accumulate, iota
 #include <vector>
 #include <utility> // pair
 


### PR DESCRIPTION
Commit bebcc093 started using `std::accumulate()` and `std::iota()`, both of which live in `<numeric>`, but failed to `#include` the required header.

The following change fixes the build for me

``` diff
diff --git a/opm/verteq/topsurf.cpp b/opm/verteq/topsurf.cpp
index 49d70f7..33462aa 100644
--- a/opm/verteq/topsurf.cpp
+++ b/opm/verteq/topsurf.cpp
@@ -13,6 +13,7 @@
 #include <iosfwd> // ostream
 #include <map>
 #include <memory> // auto_ptr
+#include <numeric>
 #include <vector>
 #include <utility> // pair
```
