### PR TITLE
fixed: mark required dependencies as such

### DIFF
--- a/cmake/Modules/opm-verteq-prereqs.cmake
+++ b/cmake/Modules/opm-verteq-prereqs.cmake
@@ -15,5 +15,6 @@ set (opm-verteq_DEPS
 	"Boost 1.44.0
 		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
 	# OPM dependency
-	"opm-core"
+	"opm-core REQUIRED"
+	"opm-parser REQUIRED"
 	)


### PR DESCRIPTION
Noticed lacking opm-parser and opm-core during packaging. This yields readable cmake error messages and not random compilation failures.

Not strictly required in release branch, but I'd backport it.