### PR TITLE
Chase SimulatorState::init() API update

### DIFF
--- a/opm/verteq/verteq.cpp
+++ b/opm/verteq/verteq.cpp
@@ -245,7 +245,9 @@ void
 VertEqImpl::upscale (const TwophaseState& fineScale,
                      TwophaseState& coarseScale) {
 	// dimension state object to the top grid
-	coarseScale.init (*ts, pr->numPhases ());
+	coarseScale.init (ts->number_of_cells,
+	                  ts->number_of_faces,
+	                  pr->numPhases ());
 
 	// upscale pressure and saturation to find the initial state of
 	// the two-dimensional domain. we only need to set the pressure


### PR DESCRIPTION
This change-set updates module opm-verteq to account for removal of initialisation method
```C++
void SimulatorState::init(const UnstructuredGrid&, const int);
```
See PR OPM/opm-core#945 for details.